### PR TITLE
fix constant name

### DIFF
--- a/lib/email_hunter/account.rb
+++ b/lib/email_hunter/account.rb
@@ -1,7 +1,7 @@
 require 'faraday'
 require 'json'
 
-API_VERIFY_URL = 'https://api.hunter.io/v2/account?'
+API_ACCOUNT_URL = 'https://api.hunter.io/v2/account?'
 
 module EmailHunter
   class Account
@@ -19,7 +19,7 @@ module EmailHunter
     private
 
     def apiresponse
-      url = URI.parse(URI.encode("#{API_VERIFY_URL}&api_key=#{@key}"))
+      url = URI.parse(URI.encode("#{API_ACCOUNT_URL}&api_key=#{@key}"))
       response = Faraday.new(url).get
       response.success? ? JSON.parse(response.body, {symbolize_names: true}) : []
     end


### PR DESCRIPTION
API_VERIFY_URL is declared twice, in EmailHunter::Verify and EmailHunter::Account.
`gems/emailhunter-0.8.0/lib/email_hunter/account.rb:4: warning: already initialized constant API_VERIFY_URL`

